### PR TITLE
docs(readme): add TOC, install flow, and proxy usage guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,87 @@
-# Introduction
-By default, Chrome use the system proxy setting (IE proxy settings on Windows platform ),
-but sometime we want to set proxy *ONLY* for chrome, not the whole system. Chrome proxy 
-helper extension use Chrome native proxy API to set proxy, support  socks5, socks4, http 
-and https protocol and pac script, Fast And Simple.
+# Chrome Proxy Helper
 
-# Features
-* support socks4, socks5, http, https, and quic proxy settings
-* support pac proxy settings
-* support bypass list
-* support online/offline pac script
-* support customer proxy rules
-* support proxy authentication
-* support extension settings synchronize
+[![License: GPL-2.0](https://img.shields.io/badge/license-GPL%202.0-blue.svg)](./COPYING)
+[![Stars](https://img.shields.io/github/stars/henices/Chrome-proxy-helper?style=social)](https://github.com/henices/Chrome-proxy-helper/stargazers)
+[![Chrome Web Store](https://img.shields.io/badge/chrome-web%20store-available-brightgreen)](https://chrome.google.com/webstore/detail/proxy-helper/mnloefcpaepkpmhaoipjkpikbnkmbnic)
 
-# Install
-* Install the latest stable version on chrome web store by click [here](https://chrome.google.com/webstore/detail/proxy-helper/mnloefcpaepkpmhaoipjkpikbnkmbnic).
-* Install the unstable version by cloning the [Git](https://github.com/henices/Chrome-proxy-helper.git) repository:
+Chrome Proxy Helper is a browser extension that lets Chrome use its own proxy settings instead of inheriting the entire system proxy configuration.
 
+## Table of Contents
+
+- [Why use it](#why-use-it)
+- [Features](#features)
+- [Installation](#installation)
+- [Usage](#usage)
+- [PAC script example](#pac-script-example)
+- [FAQ](#faq)
+- [Development notes](#development-notes)
+- [License](#license)
+
+## Why use it
+
+Chrome normally follows the operating system proxy configuration. This extension is useful when you want to route Chrome traffic through a specific proxy without changing the rest of the machine.
+
+## Features
+
+- Supports **SOCKS4**, **SOCKS5**, **HTTP**, **HTTPS**, and **QUIC** proxy modes
+- Supports **PAC script** configuration
+- Supports **online and offline** PAC files
+- Supports **bypass rules**
+- Supports **custom proxy rules**
+- Supports **proxy authentication**
+- Supports **synchronized extension settings**
+
+## Installation
+
+### Option 1: Chrome Web Store
+
+Install the latest stable version from the [Chrome Web Store](https://chrome.google.com/webstore/detail/proxy-helper/mnloefcpaepkpmhaoipjkpikbnkmbnic).
+
+### Option 2: Load from source
+
+```bash
+git clone https://github.com/henices/Chrome-proxy-helper.git
+cd Chrome-proxy-helper
 ```
-    git clone https://github.com/henices/Chrome-proxy-helper.git
-```
 
-# FAQ
+Then open `chrome://extensions`, enable **Developer mode**, click **Load unpacked**, and select the project folder.
 
-* [FAQ](https://github.com/henices/Chrome-proxy-helper/wiki/FAQ)
+## Usage
 
-## How to use pac script in this extension
+### Configure a direct proxy
 
-Here is an example PAC script: [example.pac](https://raw.githubusercontent.com/henices/Chrome-proxy-helper/refs/heads/master/example.pac)
+1. Open the extension popup.
+2. Choose the proxy type.
+3. Enter host, port, and credentials if needed.
+4. Save and enable the profile.
 
-1. options page -> PAC -> PAC script, select the example.pac
-2. popup page -> PAC Script
+### Configure a PAC script
 
-# LICENSE
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 2 of the License, or
-(at your option) any later version.
+1. Open the options page.
+2. Navigate to **PAC**.
+3. Paste the script or choose a PAC file.
+4. Enable **PAC Script** from the popup.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
- 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>
+## PAC script example
 
+A sample PAC file is available at [example.pac](./example.pac) and can also be viewed directly [here](https://raw.githubusercontent.com/henices/Chrome-proxy-helper/refs/heads/master/example.pac).
+
+## FAQ
+
+See the project [FAQ wiki page](https://github.com/henices/Chrome-proxy-helper/wiki/FAQ).
+
+## Development notes
+
+Useful project files:
+
+| Path | Purpose |
+|---|---|
+| `manifest.json` | Chrome extension manifest |
+| `background.js` | Background proxy logic |
+| `popup/` | Popup UI |
+| `options/` | Extension settings page |
+| `example.pac` | Example PAC script |
+
+## License
+
+This program is free software released under the terms of the GNU General Public License, version 2 or later. See [COPYING](./COPYING) for the full text.


### PR DESCRIPTION
## Summary
- reorganize the README around the main user problem: setting a Chrome-only proxy
- add badges, a table of contents, clearer install steps, and direct usage guidance
- surface the PAC script example and key project files for easier adoption

## Notes
README optimized with [Gingiris README Generator](https://gingiris.github.io/github-readme-generator/)
